### PR TITLE
enforceExistence: fixup enforce existance checking

### DIFF
--- a/lib/rules/validate-jsdoc/enforce-existence.js
+++ b/lib/rules/validate-jsdoc/enforce-existence.js
@@ -10,7 +10,15 @@ module.exports.options = {
  * @param {Function} err
  */
 function enforceExistence(node, err) {
-    if (!node.jsDoc && node.id) {
+    // if function is not anonymous or in variabledeclarator or in assignmentexpression
+    var parentNode = node.parentNode || {};
+    var needCheck = node.id ||
+        parentNode.type === 'VariableDeclarator' ||
+        parentNode.type === 'Property' ||
+        parentNode.type === 'AssignmentExpression' && parentNode.operator === '=';
+
+    // and report unless jsdoc exists
+    if (needCheck && !node.jsDoc) {
         err('jsdoc definition required', node.loc.start);
     }
 }

--- a/test/lib/rules/validate-jsdoc/enforce-existence.js
+++ b/test/lib/rules/validate-jsdoc/enforce-existence.js
@@ -37,10 +37,70 @@ describe('rules/validate-jsdoc', function () {
                     }
                 }
             }, {
+                it: 'should report jsdoc absence for function expressions',
+                errors: 1,
+                code: function () {
+                    var myFunc = function (v) {
+                    };
+                }
+            }, {
                 it: 'should not report jsdoc absence for anonymous functions',
                 code: function () {
                     [].forEach(function (v) {
                     });
+                }
+            }, {
+                it: 'should report nested jsdoc absence',
+                errors: 4,
+                code: function () {
+                    var MyNamespace = MyNamespace || {};
+
+                    MyNamespace.Test = function () {
+                    };
+
+                    MyNamespace.Test.Sub = {
+                        yellow: function () {
+                        }
+                    };
+
+                    (function () {
+                        MyNamespace.Test.prototype.foo = function() {
+                            function bar() {
+                            }
+                        };
+                    })();
+                }
+            }, {
+                it: 'shouldn\'t report nested jsdocs existence',
+                code: function () {
+                    var MyNamespace = MyNamespace || {};
+
+                    /**
+                     * Test
+                     */
+                    MyNamespace.Test = function () {
+                    };
+
+                    MyNamespace.Test.Sub = {
+                        /**
+                         * yellow submarine
+                         */
+                        yellow: function () {
+                        }
+                    };
+
+                    (function () {
+                        /**
+                         * Test.foo
+                         */
+                        MyNamespace.Test.prototype.foo = function() {
+                            /**
+                             * bar
+                             */
+                            function bar() {
+                            }
+                        };
+                    })();
                 }
             }
             /* jshint ignore:end */


### PR DESCRIPTION
- add tests for nested methods
- add tests for variable expressions (aka privates)
- now rule checking not only node.id (function name)

Fixes #21
