### PR TITLE
checkTypes: fixup parsing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "comment-parser": "0.2.0",
+    "comment-parser": "0.2.1",
     "doctrine": "^0.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- update comment-parser to v0.2.1 (to fix type parsing error)

Fixes #20
