### PR TITLE
fix several exceptions when validating files missing jsdoc tags

### DIFF
--- a/lib/rules/validate-jsdoc/check-param-names.js
+++ b/lib/rules/validate-jsdoc/check-param-names.js
@@ -10,24 +10,26 @@ module.exports.options = {
  * @param {Function} err
  */
 function validateCheckParamNames(node, err) {
-    node.jsdoc.iterateByType(['param', 'arg', 'argument'],
-        /**
-         * tag checker
-         * @param {DocType} tag
-         * @param {Number} i index
-         */
-        function(tag, i) {
-            var param = node.params[i];
+    if (node.jsdoc) {
+        node.jsdoc.iterateByType(['param', 'arg', 'argument'],
+            /**
+             * tag checker
+             * @param {DocType} tag
+             * @param {Number} i index
+             */
+            function(tag, i) {
+                var param = node.params[i];
 
-            // checking validity
-            if (!tag.name) {
-                return err('missing param name', tag.loc);
-            }
+                // checking validity
+                if (!tag.name) {
+                    return err('missing param name', tag.loc);
+                }
 
-            // checking name
-            if (tag.name.value !== param.name) {
-                return err('expected ' + param.name + ' but got ' + tag.name.value,
-                    tag.name.loc || node.jsdoc.loc.start);
-            }
-        });
+                // checking name
+                if (tag.name.value !== param.name) {
+                    return err('expected ' + param.name + ' but got ' + tag.name.value,
+                        tag.name.loc || node.jsdoc.loc.start);
+                }
+            });
+    }
 }

--- a/lib/rules/validate-jsdoc/check-redundant-params.js
+++ b/lib/rules/validate-jsdoc/check-redundant-params.js
@@ -10,24 +10,26 @@ module.exports.options = {
  * @param {Function} err
  */
 function validateCheckParamNames(node, err) {
-    node.jsdoc.iterateByType(['param', 'arg', 'argument'],
-        /**
-         * tag checker
-         * @param {DocType} tag
-         * @param {Number} i index
-         */
-        function(tag, i) {
-            // skip if there is dot in param name (object's inner param)
-            if (tag.name.value.indexOf('.') !== -1) {
-                return;
-            }
+    if (node.jsdoc) {
+        node.jsdoc.iterateByType(['param', 'arg', 'argument'],
+            /**
+             * tag checker
+             * @param {DocType} tag
+             * @param {Number} i index
+             */
+            function(tag, i) {
+                // skip if there is dot in param name (object's inner param)
+                if (tag.name && tag.name.value.indexOf('.') !== -1) {
+                    return;
+                }
 
-            var param = node.params[i];
-            var _optional = tag.optional || (tag.type && tag.type.optional);
+                var param = node.params[i];
+                var _optional = tag.optional || (tag.type && tag.type.optional);
 
-            // checking redundant
-            if (!_optional && !param) {
-                return err('redundant param statement');
-            }
-        });
+                // checking redundant
+                if (!_optional && !param) {
+                    return err('redundant param statement');
+                }
+            });
+    }
 }


### PR DESCRIPTION
Fixes #39 

```
TypeError: Cannot call method 'iterateByType' of null
    at Object.validateCheckParamNames (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc/check-param-names.js:13:16)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:96:27
    at Array.forEach (native)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:95:32
    at Array.forEach (native)
    at Object.JsFile.iterateNodesByType (/Volumes/samara/projects/boneskull/angular-tags/node_modules/grunt-jscs/node_modules/jscs/lib/js-file.js:284:42)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:86:18
    at Array.forEach (native)
    at Object.module.exports.check (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:78:29)
    at null.<anonymous> (/Volumes/samara/projects/boneskull/angular-tags/node_modules/grunt-jscs/node_modules/jscs/lib/string-checker.js:285:26)

```

```
TypeError: Cannot call method 'iterateByType' of null
    at Object.validateCheckParamNames (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc/check-redundant-params.js:13:16)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:96:27
    at Array.forEach (native)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:95:32
    at Array.forEach (native)
    at Object.JsFile.iterateNodesByType (/Volumes/samara/projects/boneskull/angular-tags/node_modules/grunt-jscs/node_modules/jscs/lib/js-file.js:284:42)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:86:18
    at Array.forEach (native)
    at Object.module.exports.check (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:78:29)
    at null.<anonymous> (/Volumes/samara/projects/boneskull/angular-tags/node_modules/grunt-jscs/node_modules/jscs/lib/string-checker.js:285:26)

```

```
TypeError: Cannot read property 'value' of undefined
    at DocComment.<anonymous> (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc/check-redundant-params.js:22:29)
    at DocComment.<anonymous> (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/jsdoc.js:74:16)
    at Array.forEach (native)
    at DocComment.iterateByTypes [as iterateByType] (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/jsdoc.js:70:19)
    at Object.validateCheckParamNames (/Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc/check-redundant-params.js:14:20)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:96:27
    at Array.forEach (native)
    at /Volumes/samara/projects/boneskull/angular-tags/node_modules/jscs-jsdoc/lib/rules/validate-jsdoc.js:95:32
    at Array.forEach (native)
    at Object.JsFile.iterateNodesByType (/Volumes/samara/projects/boneskull/angular-tags/node_modules/grunt-jscs/node_modules/jscs/lib/js-file.js:284:42)

```
