### PR TITLE
escape param/tag names before check

### DIFF
--- a/lib/rules/validate-jsdoc/check-param-names.js
+++ b/lib/rules/validate-jsdoc/check-param-names.js
@@ -47,6 +47,7 @@ function validateCheckParamNames(node, err) {
 
             // checking name
             var msg;
+            tag.name.value = tag.name.value.replace(/[^0-9a-zA-Z_$]/g, '');
             if (tag.name.value !== param.name && !outOfOrder[tag.name.value]) {
                 if (paramsByName[tag.name.value] && paramTagsByName[param.name]) {
                     outOfOrder[tag.name.value] = outOfOrder[param.name] = true;


### PR DESCRIPTION
about #56 to allow 

``` js
/**
 * would not report
 *
 * @param {String} `ticks`
 * @param {String} `<requiredTicks>`
 * @param {Object} `[optional]`
 * @param {Number} `[n="u m"]` some description here
 */
function methodThree(ticks, requiredTicks, optional, num) {}
```
