### PR TITLE
don't fail check-param-names on destructuring in arguments - fixes #90

### DIFF
--- a/lib/rules/validate-jsdoc/check-param-names.js
+++ b/lib/rules/validate-jsdoc/check-param-names.js
@@ -37,12 +37,17 @@ function validateCheckParamNames(node, err) {
          */
         function(tag, i) {
             // checking validity
-            if (!tag.name) {
-                // There is no parameter name in destructuring assignments.
-                if (node.params[i - skipped] && node.params[i - skipped].name === undefined) {
+
+            // There is no parameter name in destructuring assignments.
+            if (node.params[i - skipped] && node.params[i - skipped].name === undefined) {
+                // So if there is no tag name or the tag name does not contain '.', there is nothing to check.
+                if (!tag.name || tag.name.value.indexOf('.') === -1) {
+                    lastRootParamTag = tag;
                     return;
                 }
+            }
 
+            if (!tag.name) {
                 return err('Missing param name', tag.loc);
             }
 

--- a/lib/rules/validate-jsdoc/check-param-names.js
+++ b/lib/rules/validate-jsdoc/check-param-names.js
@@ -38,6 +38,11 @@ function validateCheckParamNames(node, err) {
         function(tag, i) {
             // checking validity
             if (!tag.name) {
+                // There is no parameter name in destructuring assignments.
+                if (node.params[i - skipped] && node.params[i - skipped].name === undefined) {
+                    return;
+                }
+
                 return err('Missing param name', tag.loc);
             }
 

--- a/test/lib/rules/validate-jsdoc/check-param-names.js
+++ b/test/lib/rules/validate-jsdoc/check-param-names.js
@@ -367,7 +367,6 @@ describe('lib/rules/validate-jsdoc/check-param-names', function() {
 
     });
 
-
     describe('with destructurings', function() {
         var checker = global.checker({
             plugins: ['./lib/index'],
@@ -397,6 +396,45 @@ describe('lib/rules/validate-jsdoc/check-param-names', function() {
                     '}'
                 ].join('\n')
             }, {
+                it: 'should not fail if a fake parameter name is provided',
+                code: [
+                    '/**',
+                    ' * @param {object} fakeName - description',
+                    ' */',
+                    'function obj({param}) {',
+                    '}'
+                ].join('\n')
+            }, {
+                it: 'should not fail if a fake parameter name and property description is provided',
+                code: [
+                    '/**',
+                    ' * @param {object} fakeName - description',
+                    ' * @param {object} fakeName.param - description',
+                    ' */',
+                    'function obj({param}) {',
+                    '}'
+                ].join('\n')
+            }, {
+                it: 'should report different fake parameter name',
+                code: [
+                    '/**',
+                    ' * @param {object} fakeName - description',
+                    ' * @param {object} notFakeName.param - description',
+                    ' */',
+                    'function obj({param}) {',
+                    '}'
+                ].join('\n'),
+                errors: [
+                    {
+                        column: 19,
+                        filename: 'input',
+                        line: 3,
+                        message: 'Expected `fakeName` but got `notFakeName`',
+                        rule: 'jsDoc',
+                        fixed: undefined
+                    }
+                ]
+            }, {
                 it: 'should not report an error when used next to parameters with properties',
                 code: [
                     '/**',
@@ -424,4 +462,5 @@ describe('lib/rules/validate-jsdoc/check-param-names', function() {
         ]);
 
     });
+
 });

--- a/test/lib/rules/validate-jsdoc/check-param-names.js
+++ b/test/lib/rules/validate-jsdoc/check-param-names.js
@@ -367,4 +367,61 @@ describe('lib/rules/validate-jsdoc/check-param-names', function() {
 
     });
 
+
+    describe('with destructurings', function() {
+        var checker = global.checker({
+            plugins: ['./lib/index'],
+            esnext: true
+        });
+        checker.rules({checkParamNames: true});
+
+        checker.cases([
+            /* jshint ignore:start */
+            // jscs:disable
+            {
+                it: 'should not report missing parameter name for object destructurings',
+                code: [
+                    '/**',
+                    ' * @param {object}',
+                    ' */',
+                    'function obj({param}) {',
+                    '}'
+                ].join('\n')
+            }, {
+                it: 'should not report missing parameter name for object destructurings',
+                code: [
+                    '/**',
+                    ' * @param {object}',
+                    ' */',
+                    'function obj({param: newName}) {',
+                    '}'
+                ].join('\n')
+            }, {
+                it: 'should not report an error when used next to parameters with properties',
+                code: [
+                    '/**',
+                    ' * @param {object} obj1',
+                    ' * @param {string} obj1.property',
+                    ' * @param {object}',
+                    ' * @param {object} obj2',
+                    ' * @param {string} obj2.property',
+                    ' */',
+                    'function obj(obj1, {param}, obj2) {',
+                    '}'
+                ].join('\n')
+            }, {
+                it: 'should not report missing parameter name for array destructurings',
+                code: [
+                    '/**',
+                    ' * @param {array}',
+                    ' */',
+                    'function arr([param]) {',
+                    '}'
+                ].join('\n')
+            }
+            // jscs:enable
+            /* jshint ignore:end */
+        ]);
+
+    });
 });


### PR DESCRIPTION
Here is a first stab at fixing #90.

I had to create a new ```describe``` block in the tests, since the code which should be tested requires the ```esnext``` flag for jscs.

Let me know what you think :-)