### PR TITLE
changed if to quick exit format

### DIFF
--- a/lib/rules/validate-jsdoc/require-param-types.js
+++ b/lib/rules/validate-jsdoc/require-param-types.js
@@ -14,7 +14,8 @@ module.exports.options = {
  */
 function validateParamTag(node, tag, err) {
     // checking existance
-    if (!tag.type) {
-        return err('Missing param type', (tag.name ? tag.name.loc : null) || tag.loc);
+    if (tag.type) {
+        return;
     }
+    return err('Missing param type', (tag.name ? tag.name.loc : null) || tag.loc);
 }


### PR DESCRIPTION
The if statement in the require param type rule uses the quick bail
format