### PR TITLE
Breaking out the enforceExistence check into configurable sections

### DIFF
--- a/lib/rules/validate-jsdoc/enforce-existence.js
+++ b/lib/rules/validate-jsdoc/enforce-existence.js
@@ -6,16 +6,13 @@ module.exports.options = {
     enforceExistence: true
 };
 
-// default policy
-var enforceFor;
-
 /**
  * @param {Object} options
  */
 enforceExistence.configure = function(options) {
 
     // set default policy
-    enforceFor = {
+    enforceExistence.policy = {
         all: true,
         anonymous: false,
         exports: true,
@@ -25,28 +22,28 @@ enforceExistence.configure = function(options) {
     // check options are valid
     var o = options.enforceExistence;
     assert(
-        o === true || o === false || typeof o === 'string' || (typeof o === 'object' && o.allExcept instanceof Array),
+        o === true || o === false || typeof o === 'string' || (typeof o === 'object' && Array.isArray(o.allExcept)),
         'jsDoc.enforceExistence rule was not configured properly'
     );
 
     // parse options for policies
     if (o === false) {
-        enforceFor.all = false;
+        enforceExistence.policy.all = false;
     } else if (typeof o === 'string' && o === 'exceptExports') { // backward compatible string option
-        enforceFor.exports = false;
-    } else if (typeof o === 'object' && o.allExcept instanceof Array) {
+        enforceExistence.policy.exports = false;
+    } else if (typeof o === 'object' && Array.isArray(o.allExcept)) {
         if (o.allExcept.indexOf('exports') > -1) {
-            enforceFor.exports = false;
+            enforceExistence.policy.exports = false;
         }
         if (o.allExcept.indexOf('expressions') > -1) {
-            enforceFor.expressions = false;
+            enforceExistence.policy.expressions = false;
         }
     }
 
 };
 
 /**
- * Validator for jsdoc data existance
+ * Validator for jsdoc data existence
  *
  * @param {(FunctionDeclaration|FunctionExpression)} node
  * @param {Function} err
@@ -56,17 +53,17 @@ function enforceExistence(node, err) {
     // enforce 'break-out' policies
     var parentNode = node.parentNode || {};
 
-    if (enforceFor.all === false) {
+    if (enforceExistence.policy.all === false) {
         // don't check anything
         return;
     }
-    if (enforceFor.anonymous === false) {
+    if (enforceExistence.policy.anonymous === false) {
         if (!node.id && ['AssignmentExpression', 'VariableDeclarator', 'Property'].indexOf(parentNode.type) === -1) {
             // don't check anonymous functions
             return;
         }
     }
-    if (enforceFor.exports === false) {
+    if (enforceExistence.policy.exports === false) {
         if (parentNode.type === 'AssignmentExpression') {
             var left = parentNode.left;
             if ((left.object && left.object.name) === 'module' &&
@@ -76,7 +73,7 @@ function enforceExistence(node, err) {
             }
         }
     }
-    if (enforceFor.expressions === false) {
+    if (enforceExistence.policy.expressions === false) {
         if (['AssignmentExpression', 'VariableDeclarator', 'Property'].indexOf(parentNode.type) > -1) {
             // don't check expression functions
             return;

--- a/lib/rules/validate-jsdoc/enforce-existence.js
+++ b/lib/rules/validate-jsdoc/enforce-existence.js
@@ -1,7 +1,48 @@
+var assert = require('assert');
+
 module.exports = enforceExistence;
 module.exports.scopes = ['function'];
 module.exports.options = {
-    enforceExistence: {allowedValues: [true, 'exceptExports']}
+    enforceExistence: true
+};
+
+// default policy
+var enforceFor;
+
+/**
+ * @param {Object} options
+ */
+enforceExistence.configure = function(options) {
+
+    // set default policy
+    enforceFor = {
+        all: true,
+        anonymous: false,
+        exports: true,
+        expressions: true
+    };
+
+    // check options are valid
+    var o = options.enforceExistence;
+    assert(
+        o === true || o === false || typeof o === 'string' || (typeof o === 'object' && o.allExcept instanceof Array),
+        'jsDoc.enforceExistence rule was not configured properly'
+    );
+
+    // parse options for policies
+    if (o === false) {
+        enforceFor.all = false;
+    } else if (typeof o === 'string' && o === 'exceptExports') { // backward compatible string option
+        enforceFor.exports = false;
+    } else if (typeof o === 'object' && o.allExcept instanceof Array) {
+        if (o.allExcept.indexOf('exports') > -1) {
+            enforceFor.exports = false;
+        }
+        if (o.allExcept.indexOf('expressions') > -1) {
+            enforceFor.expressions = false;
+        }
+    }
+
 };
 
 /**
@@ -11,28 +52,43 @@ module.exports.options = {
  * @param {Function} err
  */
 function enforceExistence(node, err) {
-    var reportExports = this._options.enforceExistence !== 'exceptExports';
 
-    // if function is not anonymous or in variabledeclarator or in assignmentexpression
+    // enforce 'break-out' policies
     var parentNode = node.parentNode || {};
-    var needCheck = node.id ||
-        parentNode.type === 'VariableDeclarator' ||
-        parentNode.type === 'Property' ||
-        parentNode.type === 'AssignmentExpression' && parentNode.operator === '=';
 
-    if (!reportExports && needCheck && parentNode.type === 'AssignmentExpression') {
-        var left = parentNode.left;
-        if ((left.object && left.object.name) === 'module' &&
-            (left.property && left.property.name) === 'exports') {
-            needCheck = false;
+    if (enforceFor.all === false) {
+        // don't check anything
+        return;
+    }
+    if (enforceFor.anonymous === false) {
+        if (!node.id && ['AssignmentExpression', 'VariableDeclarator', 'Property'].indexOf(parentNode.type) === -1) {
+            // don't check anonymous functions
+            return;
+        }
+    }
+    if (enforceFor.exports === false) {
+        if (parentNode.type === 'AssignmentExpression') {
+            var left = parentNode.left;
+            if ((left.object && left.object.name) === 'module' &&
+                (left.property && left.property.name) === 'exports') {
+                // don't check exports functions
+                return;
+            }
+        }
+    }
+    if (enforceFor.expressions === false) {
+        if (['AssignmentExpression', 'VariableDeclarator', 'Property'].indexOf(parentNode.type) > -1) {
+            // don't check expression functions
+            return;
         }
     }
 
-    // skip unless jsdoc exists and check is needed
-    if (node.jsdoc || !needCheck) {
+    // now clear to check for documentation
+    if (node.jsdoc) {
         return;
     }
 
     // report absence
     err('jsdoc definition required', node.loc.start);
+
 }

--- a/test/lib/rules/validate-jsdoc/enforce-existence.js
+++ b/test/lib/rules/validate-jsdoc/enforce-existence.js
@@ -3,20 +3,36 @@ describe('lib/rules/validate-jsdoc/enforce-existence', function () {
         plugins: ['./lib/index']
     });
 
-    describe('not configured', function() {
+    //describe('not configured', function() {
+    //
+    //    it('should report with undefined', function() {
+    //        global.expect(function() {
+    //            checker.configure({enforceExistence: undefined});
+    //        }).to.throws(/accepted value/i);
+    //    });
+    //
+    //    it('should report with an object', function() {
+    //        global.expect(function() {
+    //            checker.configure({enforceExistence: {}});
+    //        }).to.throws(/accepted value/i);
+    //    });
+    //
+    //});
 
-        it('should report with undefined', function() {
-            global.expect(function() {
-                checker.configure({enforceExistence: undefined});
-            }).to.throws(/accepted value/i);
-        });
+    describe('with false', function() {
+        checker.rules({enforceExistence: false});
 
-        it('should report with an object', function() {
-            global.expect(function() {
-                checker.configure({enforceExistence: {}});
-            }).to.throws(/accepted value/i);
-        });
-
+        checker.cases([
+            /* jshint ignore:start */
+            {
+                it: 'should not report jsdocs existence for function',
+                code: function () {
+                    function funcName(p) {
+                    }
+                }
+            }
+            /* jshint ignore:end */
+        ]);
     });
 
     describe('with true', function() {
@@ -140,6 +156,39 @@ describe('lib/rules/validate-jsdoc/enforce-existence', function () {
                 it: 'should not report jsdocs existence for module.exports anonymous function',
                 code: function () {
                     module.exports = function () {
+                    };
+                }
+            }
+            /* jshint ignore:end */
+        ]);
+    });
+
+    describe('with allExcept exports', function() {
+        checker.rules({enforceExistence: {allExcept: ['exports']}});
+
+        checker.cases([
+            /* jshint ignore:start */
+            {
+                it: 'should not report jsdocs existence for module.exports anonymous function',
+                errors: 0,
+                code: function () {
+                    module.exports = function () {
+                    };
+                }
+            }
+            /* jshint ignore:end */
+        ]);
+    });
+
+    describe('with allExcept expressions', function() {
+        checker.rules({enforceExistence: {allExcept: ['expressions']}});
+
+        checker.cases([
+            /* jshint ignore:start */
+            {
+                it: 'should not report jsdocs existence for expressions functions',
+                code: function () {
+                    var x = function () {
                     };
                 }
             }

--- a/test/lib/rules/validate-jsdoc/enforce-existence.js
+++ b/test/lib/rules/validate-jsdoc/enforce-existence.js
@@ -3,21 +3,21 @@ describe('lib/rules/validate-jsdoc/enforce-existence', function () {
         plugins: ['./lib/index']
     });
 
-    //describe('not configured', function() {
-    //
-    //    it('should report with undefined', function() {
-    //        global.expect(function() {
-    //            checker.configure({enforceExistence: undefined});
-    //        }).to.throws(/accepted value/i);
-    //    });
-    //
-    //    it('should report with an object', function() {
-    //        global.expect(function() {
-    //            checker.configure({enforceExistence: {}});
-    //        }).to.throws(/accepted value/i);
-    //    });
-    //
-    //});
+    describe('not configured', function() {
+
+        it('should report with undefined', function() {
+            global.expect(function() {
+                checker.configure({enforceExistence: undefined});
+            }).to.throws(/jsDoc.enforceExistence rule was not configured properly/i);
+        });
+
+        it('should report with an object', function() {
+            global.expect(function() {
+                checker.configure({enforceExistence: {allExcept: 'something invalid'}});
+            }).to.throws(/jsDoc.enforceExistence rule was not configured properly/i);
+        });
+
+    });
 
     describe('with false', function() {
         checker.rules({enforceExistence: false});
@@ -169,7 +169,7 @@ describe('lib/rules/validate-jsdoc/enforce-existence', function () {
         checker.cases([
             /* jshint ignore:start */
             {
-                it: 'should not report jsdocs existence for module.exports anonymous function',
+                it: 'should not report jsdocs existence for export functions',
                 errors: 0,
                 code: function () {
                     module.exports = function () {
@@ -186,9 +186,28 @@ describe('lib/rules/validate-jsdoc/enforce-existence', function () {
         checker.cases([
             /* jshint ignore:start */
             {
-                it: 'should not report jsdocs existence for expressions functions',
+                it: 'should not report jsdocs existence for expression functions',
                 code: function () {
                     var x = function () {
+                    };
+                }
+            }
+            /* jshint ignore:end */
+        ]);
+    });
+
+    describe('with allExcept exports and expressions', function() {
+        checker.rules({enforceExistence: {allExcept: ['exports', 'expressions']}});
+
+        checker.cases([
+            /* jshint ignore:start */
+            {
+                it: 'should not report jsdocs existence for both export and expression functions',
+                code: function () {
+                    var x = function () {
+                    };
+
+                    module.exports = function () {
                     };
                 }
             }


### PR DESCRIPTION
Can now specify checking documentation existence for:
- All functions
- Anonymous functions
- Expression functions
- Exports functions