### PR TITLE
Fix trailing non-word characters before period not matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,11 @@ function method() {}
 function method() {}
 
 /**
+ * (Description).
+ */
+function method() {}
+
+/**
  * Description.
  *
  * @param {String} - message

--- a/lib/rules/validate-jsdoc/require-description-complete-sentence.js
+++ b/lib/rules/validate-jsdoc/require-description-complete-sentence.js
@@ -31,8 +31,10 @@ var RE_NEW_LINE_UPPERCASE = /\w(?![.])(\W)*\n\W*[A-Z]/g;
  *
  * If the above line did not have a period this would match.
  * this also ensures that the last sentence in the description ends with a period.
+ *
+ * This also matches white-space followed by a period.
  */
-var RE_END_WITH_PERIOD = /\w(?![.])(\W)*(\n|$)[*\s]*(\n|$)/g;
+var RE_END_WITH_PERIOD = /(\s\.|[^\s\.])(?!\.)(\n|$)[*\s]*(\n|$)/g;
 
 /**
  * Requires description to be a complete sentence in a jsdoc comment.

--- a/test/lib/rules/validate-jsdoc/require-description-complete-sentence.js
+++ b/test/lib/rules/validate-jsdoc/require-description-complete-sentence.js
@@ -119,7 +119,7 @@ describe('lib/rules/validate-jsdoc/require-description-complete-sentence', funct
                     function fun(p) {}
                 }
             }, {
-                it: 'should report missing period',
+                it: 'should report trailing white-space',
                 code: function () {
                     /**
                      * Some description .
@@ -129,6 +129,17 @@ describe('lib/rules/validate-jsdoc/require-description-complete-sentence', funct
                     function fun(p) {}
                 },
                 errors: 1
+            }, {
+                it: 'should not report final non-word characters',
+                code: function () {
+                    /**
+                     * Some `description`.
+                     *
+                     * @param {number} p description without hyphen
+                     */
+                    function fun(p) {}
+                },
+                errors: 0
             }, {
                 it: 'should report missing period at end of first line',
                 code: function () {


### PR DESCRIPTION
```js
/**
 * (Description).
 */
function method() {}
```

...was previously seens as having no final perdiod. This
fixes that behavior.

Closes GH-123.