### PR TITLE
Misc: skip checking for incorrectly formatted jsdoc blocks

### DIFF
--- a/lib/rules/validate-jsdoc.js
+++ b/lib/rules/validate-jsdoc.js
@@ -122,7 +122,7 @@ module.exports.prototype = {
                 }
 
                 validators = _this._rulesForTags[scope];
-                if (!validators || !node.jsdoc) {
+                if (!validators || !node.jsdoc || !node.jsdoc.valid) {
                     return;
                 }
 

--- a/lib/rules/validate-jsdoc/check-param-names.js
+++ b/lib/rules/validate-jsdoc/check-param-names.js
@@ -11,7 +11,7 @@ module.exports.options = {
  * @param {Function} err
  */
 function validateCheckParamNames(node, err) {
-    if (!node.jsdoc) {
+    if (!node.jsdoc || !node.jsdoc.valid) {
         return;
     }
 

--- a/lib/rules/validate-jsdoc/check-redundant-access.js
+++ b/lib/rules/validate-jsdoc/check-redundant-access.js
@@ -14,7 +14,7 @@ module.exports.options = {
 function checkRedundantAccess(node, err) {
     var enforceLeadingUnderscore = this._options.checkRedundantAccess === 'enforceLeadingUnderscore';
     var enforceTrailingUnderscore = this._options.checkRedundantAccess === 'enforceTrailingUnderscore';
-    if (!node.jsdoc) {
+    if (!node.jsdoc || !node.jsdoc.valid) {
         return;
     }
 

--- a/lib/rules/validate-jsdoc/check-redundant-params.js
+++ b/lib/rules/validate-jsdoc/check-redundant-params.js
@@ -11,7 +11,7 @@ module.exports.options = {
  * @param {Function} err
  */
 function validateCheckParamNames(node, err) {
-    if (!node.jsdoc) {
+    if (!node.jsdoc || !node.jsdoc.valid) {
         return;
     }
 

--- a/lib/rules/validate-jsdoc/leading-underscore-access.js
+++ b/lib/rules/validate-jsdoc/leading-underscore-access.js
@@ -39,7 +39,7 @@ var nativeUnderscoredProperties = [
  */
 function validateLeadingUnderscoresAccess(node, err) {
     var option = this._options.leadingUnderscoreAccess;
-    if (!node.jsdoc) {
+    if (!node.jsdoc || !node.jsdoc.valid) {
         return;
     }
 

--- a/test/lib/rules/validate-jsdoc/leading-underscore-access.js
+++ b/test/lib/rules/validate-jsdoc/leading-underscore-access.js
@@ -203,6 +203,30 @@ describe('lib/rules/validate-jsdoc/leading-underscore-access', function () {
                     var __proto__ = function (p) {};
                 }
             }, {
+                it: 'should not report private functions. jscs-dev/node-jscs#1588',
+                rules: {leadingUnderscoreAccess: 'private'},
+                code: function () {
+                    /**
+                     * @access private
+                     */
+                    function _super(p) {};
+
+                    /**
+                     * @private
+                     */
+                    function _proto(p) {};
+                }
+            }, {
+                it: 'should not report incorrect jsdoc with right tag. jscs-dev/node-jscs#1588',
+                rules: {leadingUnderscoreAccess: 'private'},
+                code: function() {
+                    /**
+                    * @private
+                    **/
+                    function _yay(yey) {
+                    }
+                }
+            }, {
                 it: 'should not report overriden methods. #114',
                 rules: {leadingUnderscoreAccess: 'private'},
                 code: function () {


### PR DESCRIPTION
Fixes jscs-dev/node-jscs#1588