### PR TITLE
Misc: find docblock separated by an extra newline

### DIFF
--- a/lib/rules/validate-jsdoc.js
+++ b/lib/rules/validate-jsdoc.js
@@ -230,24 +230,43 @@ function patchNodesInFile(file) {
      */
     function getJsdoc() {
         if (!this.hasOwnProperty('_jsdoc')) {
-            var res = findDocCommentBeforeLine(this.loc.start.line);
+            var node = (this.type === 'FunctionExpression') ? findFirstNodeInLine(this) : this;
+            var res = findDocCommentBeforeNode(node);
             this._jsdoc = res ? jsdoc.createDocCommentByCommentNode(res) : null;
         }
         return this._jsdoc;
     }
 
     /**
-     * Finds DocComment in file before passed line number
+     * Finds the first node on the same line as passed node
      *
-     * @param {number} line
+     * @param {?module:esprima/Node} node
      * @returns {?module:esprima/Node}
      */
-    function findDocCommentBeforeLine(line) {
-        line--; // todo: buggy behaviour, can't jump back over empty lines
+    function findFirstNodeInLine(node) {
+        var parent = node.parentNode;
+        if (!parent || parent.loc.start.line !== node.loc.start.line) {
+            return node;
+        }
+        return findFirstNodeInLine(parent);
+    }
+
+    /**
+     * Finds DocComment in file before passed line number
+     *
+     * @param {?module:esprima/Node} node
+     * @returns {?module:esprima/Node}
+     */
+    function findDocCommentBeforeNode(node) {
+        var line = node.loc.start.line;
+        var column = node.loc.start.column;
+
         for (var i = 0, l = fileComments.length; i < l; i++) {
             var commentNode = fileComments[i];
-            // v.substr(jsdoc.loc.start.column);
-            if (commentNode.loc.end.line === line && commentNode.type === 'Block' &&
+            var endLine = commentNode.loc.end.line;
+            if ((endLine === line - 1 || endLine === line - 2) &&
+                commentNode.loc.start.column === column &&
+                commentNode.type === 'Block' &&
                 commentNode.value.charAt(0) === '*') {
                 return commentNode;
             }

--- a/test/lib/rules/validate-jsdoc.js
+++ b/test/lib/rules/validate-jsdoc.js
@@ -52,6 +52,16 @@ describe('lib/rules/validate-jsdoc', function () {
                         // doesn't mean
                     }
                 }
+            }, {
+                it: 'finds docblock after a blank line',
+                rules: {checkReturnTypes: true},
+                code: function() {
+                    /**
+                     * Foo
+                     */
+
+                    function foo () {}
+                }
             }
             /* jshint ignore:end */
         ]);


### PR DESCRIPTION
On my team we habitually add an extra newline after docblocks. This pull request allows a docblock to be separated from the thing it documents by one or two newlines. It additionally requires a docblock to be indented at the same level as the thing it documents.

Both valid:

```js
/**
 * Get a foo
 */
function foo () {}

/**
 * Get a bar
 */

function bar () {}
```

And this is not:

```js
/**
 * Get a foo
 */
    function foo () {}
```
