### PR TITLE
Override is a valid tag

### DIFF
--- a/lib/tags/jsdoc3.json
+++ b/lib/tags/jsdoc3.json
@@ -52,6 +52,7 @@
     "module": true,
     "name": true,
     "namespace": true,
+    "override": false,
     "overview": true,
     "param": true,
     "private": false,


### PR DESCRIPTION
I just ran into a validation issue where `override` was flagged as invalid. I think this is all that's needed to fix that.