### PR TITLE
Add @override tag support

### DIFF
--- a/lib/tags/jsdoc3.json
+++ b/lib/tags/jsdoc3.json
@@ -52,6 +52,7 @@
     "module": true,
     "name": true,
     "namespace": true,
+    "override": true,
     "overview": true,
     "param": true,
     "private": false,


### PR DESCRIPTION
It used at Google JS Style Guide:

@override
For example:

```
/**
 * @return {string} Human-readable representation of project.SubClass.
 * @override
 */
project.SubClass.prototype.toString = function() {
  // ...
};
```

https://google.github.io/styleguide/javascriptguide.xml?showone=Comments#Comments