### PR TITLE
Bump comment-parser to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "comment-parser": "0.3.0",
+    "comment-parser": "^0.3.1",
     "jsdoctypeparser": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
(I'm not sure why this dep was pinned, this means all the downstreams will need to manually bump to get this fix. hopefully using a proper semver range is acceptable)

[v0.3.1 of comment-parser](https://github.com/yavorskiy/comment-parser/pull/24#issuecomment-159669144) uses the `readable-stream` module, which allows compatibility with node 0.8 and earlier. Whether you want to support node 0.8 isn't important - for your module, this change will function identically for > 0.8, and simply won't break for *this* reason on <= 0.8 - a net win!