### PR TITLE
requireDescriptionCompleteSentence: To detect and ignore HTML content

### DIFF
--- a/lib/rules/validate-jsdoc/require-description-complete-sentence.js
+++ b/lib/rules/validate-jsdoc/require-description-complete-sentence.js
@@ -56,7 +56,9 @@ function requireDescriptionCompleteSentence(node, err) {
         .replace(/(`)([^`]+)\1/, quotedSanitizer)
         .replace(/(')([^']+)\1/, quotedSanitizer)
         .replace(/(")([^"]+)\1/, quotedSanitizer)
+        // sanitize HTML tags which close
         .replace(/<([^ >]+)[^>]*>[\s\S]*?.*?<\/\1>|<[^\/]+\/>/g, htmlSanitizer)
+        // sanitize self-closing HTML tags eg <br>
         .replace(/<([^ >]+)[^>]*>/g, htmlSanitizer)
         .replace(/\{([^}]+)\}/, function(_, m) {
             return '{' + (new Array(m.length + 1)).join('*') + '}';
@@ -66,7 +68,9 @@ function requireDescriptionCompleteSentence(node, err) {
             return ':' + n.replace(/\n/g, ' ');
         });
     var lines = sanitized.split(RE_END_DESCRIPTION);
+
     var errors = [];
+
     if (START_DESCRIPTION.test(sanitized)) {
         var matches = returnAllMatches(sanitized, START_DESCRIPTION);
         matches.map(function(match) {

--- a/lib/rules/validate-jsdoc/require-description-complete-sentence.js
+++ b/lib/rules/validate-jsdoc/require-description-complete-sentence.js
@@ -56,6 +56,8 @@ function requireDescriptionCompleteSentence(node, err) {
         .replace(/(`)([^`]+)\1/, quotedSanitizer)
         .replace(/(')([^']+)\1/, quotedSanitizer)
         .replace(/(")([^"]+)\1/, quotedSanitizer)
+        .replace(/<([^ >]+)[^>]*>[\s\S]*?.*?<\/\1>|<[^\/]+\/>/g, htmlSanitizer)
+        .replace(/<([^ >]+)[^>]*>/g, htmlSanitizer)
         .replace(/\{([^}]+)\}/, function(_, m) {
             return '{' + (new Array(m.length + 1)).join('*') + '}';
         })
@@ -64,9 +66,7 @@ function requireDescriptionCompleteSentence(node, err) {
             return ':' + n.replace(/\n/g, ' ');
         });
     var lines = sanitized.split(RE_END_DESCRIPTION);
-
     var errors = [];
-
     if (START_DESCRIPTION.test(sanitized)) {
         var matches = returnAllMatches(sanitized, START_DESCRIPTION);
         matches.map(function(match) {
@@ -178,4 +178,20 @@ function returnAllMatches(input, regex) {
 function quotedSanitizer(_, q, m) {
     var endsWithDot = /\.\s*$/.test(m);
     return q + (new Array(m.length + (endsWithDot ? 0 : 1))).join('*') + q + (endsWithDot ? '.' : '');
+}
+
+/**
+ * HTML part sanitizer.
+ * To prevent RE_NEW_LINE_START_WITH_UPPER_CASE
+ * return string will padded by 'x.'
+ *
+ * @private
+ * @param {string} _ - Full matched string
+ * @returns {string} - Sanitized string
+ */
+function htmlSanitizer(_) {
+  return _.split('').map(function(token, iterator) {
+    if (iterator === _.length - 1) { return 'x.'}
+    return token === '\n' ? '\n' : '*';
+  }).join('');
 }

--- a/test/lib/rules/validate-jsdoc/require-description-complete-sentence.js
+++ b/test/lib/rules/validate-jsdoc/require-description-complete-sentence.js
@@ -232,6 +232,28 @@ describe('lib/rules/validate-jsdoc/require-description-complete-sentence', funct
                      */
                     function quux() {}
                 }
+            }, {
+                it: 'should not report sentences with html tags inside',
+                code: function () {
+                    /**
+                     * A foo is assigned the boolean value <p>true</p>.
+                     */
+                    function fun(p) {}
+                }
+            }, {
+                it: 'should not report sentences that are html code',
+                code: function () {
+                  /**
+                   * The html code here
+                   * <body>
+                   *  <p> Hello world!</p>
+                   * </body>
+                   * Should always be there.
+                   * And the first letter of this line is in
+                   * uppercase.
+                   */
+                  function fun(p) {}
+                }
             }
             /* jshint ignore:end */
         ]);


### PR DESCRIPTION
This rule has been flagging comments with html tags.
In this patch the html is sanitized with *** so that it doesn't
interfere with the regular regex tests. The htmlSanitizer function
is padding all strings with 'x.' so that RE_NEW_LINE_START_WITH_UPPER_CASE
doesnt fail. This will need to be improved after discussing with owner if he/she
thinks so.

Fixes jscs-dev/node-jscs#2056